### PR TITLE
Use state information on get city location

### DIFF
--- a/src/geolocation/hooks/use-get-city-location/use-get-city-location.test.ts
+++ b/src/geolocation/hooks/use-get-city-location/use-get-city-location.test.ts
@@ -18,14 +18,27 @@ describe("useGetCityLocation", () => {
   });
 
   it("shouldn't fetch data if city name is undefined", async () => {
-    const { result } = renderCustomHook(useGetCityLocation);
+    const { result } = renderCustomHook(() =>
+      useGetCityLocation(undefined, "Paraná")
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("should't fetch data if the state is undefined", async () => {
+    const { result } = renderCustomHook(() =>
+      useGetCityLocation("Curitiba", undefined)
+    );
 
     expect(result.current.data).toBeUndefined();
     expect(result.current.fetchStatus).toBe("idle");
   });
 
   it("should return city geolocation if city name is defined", async () => {
-    const { result } = renderCustomHook(() => useGetCityLocation("Curitiba"));
+    const { result } = renderCustomHook(() =>
+      useGetCityLocation("Curitiba", "Paraná")
+    );
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);

--- a/src/geolocation/hooks/use-get-city-location/use-get-city-location.ts
+++ b/src/geolocation/hooks/use-get-city-location/use-get-city-location.ts
@@ -2,21 +2,21 @@ import { useQuery } from "@tanstack/react-query";
 import { Geolocation, buildGeolocationDTO } from "@/geolocation/dto";
 import { GeolocationService } from "@/geolocation/service";
 
-export const useGetCityLocation = (cityName?: string) => {
-  const hasCityName = !!cityName;
+export const useGetCityLocation = (cityName?: string, state?: string) => {
+  const hasLocationInfo = !!state && !!cityName;
   const geolocationService = new GeolocationService();
 
   const getCityLocation = async () => {
     return geolocationService
-      .getCityLocation(cityName)
+      .getCityLocation(cityName, state)
       .then(({ data: [cityGeolocation] }) =>
         buildGeolocationDTO(cityGeolocation)
       );
   };
 
   return useQuery<Geolocation>({
-    queryKey: ["getCityLocation", cityName],
+    queryKey: ["getCityLocation", state, cityName],
     queryFn: getCityLocation,
-    enabled: hasCityName,
+    enabled: hasLocationInfo,
   });
 };

--- a/src/geolocation/service/geolocation.test.ts
+++ b/src/geolocation/service/geolocation.test.ts
@@ -19,7 +19,7 @@ describe("GeolocationService", () => {
 
       const {
         data: [remoteGeolocation],
-      } = await geolocationService.getCityLocation("Curitiba,BR");
+      } = await geolocationService.getCityLocation("Curitiba", "Paraná");
 
       expect(remoteGeolocation.lat).toBe(-25.4295963);
       expect(remoteGeolocation.lon).toBe(-49.2712724);

--- a/src/geolocation/service/geolocation.ts
+++ b/src/geolocation/service/geolocation.ts
@@ -6,10 +6,15 @@ export class GeolocationService {
   #axiosInstance: AxiosInstance = openWeatherAxiosInstance;
 
   async getCityLocation(
-    searchParam?: string,
+    cityName?: string,
+    state?: string,
     limit: string = "1"
   ): Promise<AxiosResponse<RemoteGeolocation[]>> {
-    const params = { q: searchParam, appid: envObject.apiKey, limit };
+    const params = {
+      q: `${cityName},${state},BR`,
+      appid: envObject.apiKey,
+      limit,
+    };
     return await this.#axiosInstance.get("/geo/1.0/direct", {
       params,
     });

--- a/src/weather/pages/city-weather/city-weather.test.tsx
+++ b/src/weather/pages/city-weather/city-weather.test.tsx
@@ -28,7 +28,7 @@ describe("CityWeather", () => {
   it("should render component with city weather", async () => {
     vi.mock("react-router-dom", async () => ({
       ...(await vi.importActual("react-router-dom")),
-      useParams: () => ({ cityName: "Curitiba" }),
+      useParams: () => ({ state: "Paraná", cityName: "Curitiba" }),
     }));
 
     renderComponent(<CityWeather />);

--- a/src/weather/pages/city-weather/city-weather.tsx
+++ b/src/weather/pages/city-weather/city-weather.tsx
@@ -13,8 +13,8 @@ import {
 
 export const CityWeather = () => {
   const navigate = useNavigate();
-  const { cityName } = useParams();
-  const { data: cityLocation } = useGetCityLocation(cityName);
+  const { cityName, state } = useParams();
+  const { data: cityLocation } = useGetCityLocation(cityName, state);
   const { data: locationWeather } = useGetLocationWeather(
     cityLocation?.lat,
     cityLocation?.lon


### PR DESCRIPTION
### Why is this pull request necessary?
- We want to have the correct location of a city based on his state, so that cities like Cascavel that exist on two or more states (PR and CE) show the correct information

### What changes does this pull request add?
- Accept the state param on get city location service and hook
- Use the state information on get city location